### PR TITLE
chore(influxdb): bump influxdb 1.8 to 1.12

### DIFF
--- a/advanced/docker-compose.yml
+++ b/advanced/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - historian_default
 
   influxdb:
-    image: "influxdb:1.8"
+    image: "influxdb:1.12"
     hostname: influx
     environment:
       INFLUXDB_HTTP_AUTH_ENABLED: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - historian_default
 
   influxdb:
-    image: "influxdb:1.8"
+    image: "influxdb:1.12"
     hostname: "influx"
     environment:
       INFLUXDB_HTTP_AUTH_ENABLED: "true"


### PR DESCRIPTION
## Summary
Bump InfluxDB image `1.8` to `1.12` in the two docker-compose stacks in this repo:
- `docker-compose.yml`
- `advanced/docker-compose.yml`

1.x TSM storage format is unchanged between 1.8 and 1.12, so existing data volumes mount fine. No down-migration needed.

## Work item
Bug/PBI 36549 (influxd 1.12): https://dev.azure.com/factry/Historian/_workitems/edit/36549

## Testing
`docker compose up` in each dir; InfluxDB container starts on 1.12 and Historian connects.